### PR TITLE
attempt at creating server time conversion to client's local timezone

### DIFF
--- a/client/components/entry-list-item.jsx
+++ b/client/components/entry-list-item.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { serverDateFormatter, serverTimeFormatter } from './time-server-converter';
 
 class EntryListItem extends React.Component {
   constructor(props) {
@@ -79,9 +80,13 @@ class EntryListItem extends React.Component {
           </div>
           <div className="note-container">
             <h3 className="entry-list-time">
+              {serverDateFormatter(this.props.entry.time)}
+              <span className="entry-hour">{serverTimeFormatter(this.props.entry.time)}</span>
+            </h3>
+            {/* <h3 className="entry-list-time">
               {this.props.entry.date}
               <span className="entry-hour">{this.props.entry.hour}</span>
-            </h3>
+            </h3> */}
             <div className="event-partic-container">
               <p className="event-with">{this.props.entry.event}</p>
               <p className="event-with">{this.props.entry.participants}</p>

--- a/client/components/time-server-converter.jsx
+++ b/client/components/time-server-converter.jsx
@@ -1,0 +1,40 @@
+function serverDateFormatter(serverTimestamp) {
+  // console.log(serverTimestamp);
+  const date = new Date(serverTimestamp);
+  const dayNum = date.getDay();
+  const monthNum = date.getMonth();
+  const dayDate = date.getDate();
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec'
+  ];
+  const daysOfWeek = [
+    'Sun',
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat'
+  ];
+  return `${daysOfWeek[dayNum]}, ${dayDate} ${months[monthNum]} | `;
+}
+
+function serverTimeFormatter(serverTimestamp) {
+  // console.log(serverTimestamp);
+  const time = new Date(serverTimestamp);
+  const formattedTime = time.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  return formattedTime;
+}
+
+export { serverDateFormatter, serverTimeFormatter };


### PR DESCRIPTION
-When deployed, server converts all timestamps to GMT +0.
-Instead of formatting the SQL query, I made a time-server-converter.jsx that takes in the server timestamp, converts it to a date object, and then formats the date on the client side.
possibly remove lines 191-192 on index.js since I just use line 185 now.

There is also some To_Char backend formatting on lines 169-172.  Not sure if this will cause an issue with timezones as well.